### PR TITLE
Fix update breaking old versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "zng-webrender"
-version = "0.63.0"
+version = "0.63.1"
 dependencies = [
  "bincode",
  "bitflags 2.5.0",
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "zng-wr-glyph-rasterizer"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "core-foundation 0.9.4",
  "core-graphics 0.23.2",

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-webrender"
-version = "0.63.0"
+version = "0.63.1"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/zng-ui/zng-webrender"
@@ -46,7 +46,7 @@ smallvec = "1.13"
 api = { version = "0.63.0", path = "../webrender_api", package = "zng-webrender-api" }
 webrender_build = { version = "0.0.4", path = "../webrender_build", package = "zng-webrender-build" }
 malloc_size_of = { version = "0.0.3", path = "../wr_malloc_size_of", package = "zng-wr-malloc-size-of" }
-glyph_rasterizer = { version = "0.1.2", path = "../wr_glyph_rasterizer", package = "zng-wr-glyph-rasterizer", default-features = false }
+glyph_rasterizer = { version = "0.2.0", path = "../wr_glyph_rasterizer", package = "zng-wr-glyph-rasterizer", default-features = false }
 svg_fmt = "0.4"
 tracy-rs = "0.1.2"
 derive_more = { version = "0.99", default-features = false, features = ["add_assign"] }

--- a/wr_glyph_rasterizer/Cargo.toml
+++ b/wr_glyph_rasterizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wr-glyph-rasterizer"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["The Mozilla Project Developers"]
 description = "A glyph rasterizer for WebRender"
 license = "MPL-2.0"


### PR DESCRIPTION
wr-glyph-rasterizer 0.1.2 uses the breaking webrender-api 0.63, but it is not a breaking change.

Will publish this update and yank rasterizer and webrender (cause it must rasterizer 0.2)