### PR TITLE
Fix swgl build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "zng-swgl"
-version = "0.2.0"
+version = "0.3.1"
 dependencies = [
  "cc",
  "gleam",
@@ -2877,7 +2877,7 @@ dependencies = [
 
 [[package]]
 name = "zng-webrender"
-version = "0.63.1"
+version = "0.64.1"
 dependencies = [
  "allocator-api2",
  "bincode",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "zng-webrender-api"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "app_units",
  "bitflags 2.6.0",
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "zng-wr-glyph-rasterizer"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "core-foundation 0.9.4",
  "core-graphics 0.23.2",

--- a/swgl/Cargo.toml
+++ b/swgl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-swgl"
-version = "0.3.0"
+version = "0.3.1"
 license = "MPL-2.0"
 authors = ["The Mozilla Project Developers"]
 build = "build.rs"

--- a/swgl/build.rs
+++ b/swgl/build.rs
@@ -86,8 +86,6 @@ fn translate_shader(shader_key: &str, shader_dir: &str) {
             build.flag("-xc").flag("-P").flag("-undef");
         }
     }
-    // Use SWGLPP target to avoid pulling CFLAGS/CXXFLAGS.
-    build.target("SWGLPP");
     build.file(&imp_name);
     let vs = build.clone()
         .define("WR_VERTEX_SHADER", Some("1"))

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-webrender"
-version = "0.64.0"
+version = "0.64.1"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/zng-ui/zng-webrender"
@@ -52,7 +52,7 @@ tracy-rs = "0.1.2"
 derive_more = { version = "0.99", default-features = false, features = ["add_assign"] }
 peek-poke = { version = "0.3.2", path = "../peek-poke", package = "zng-peek-poke" }
 etagere = "0.2.13"
-swgl = { path = "../swgl", optional = true, version = "0.3.0", package = "zng-swgl" }
+swgl = { path = "../swgl", optional = true, version = "0.3.1", package = "zng-swgl" }
 topological-sort = "0.1"
 allocator-api2 = { version = "0.2.18", features = ["alloc", "serde"] }
 


### PR DESCRIPTION
Remove invalid target from swgl build script. Targets are now validated by  `cc`.